### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/devylawyer/3db72a94-2802-4ab6-80ee-da1adfdaf803/c1c32732-e42a-4552-87f5-77cd77dd552a/_apis/work/boardbadge/8a59969a-9c1f-486b-be5d-c6070964f697)](https://dev.azure.com/devylawyer/3db72a94-2802-4ab6-80ee-da1adfdaf803/_boards/board/t/c1c32732-e42a-4552-87f5-77cd77dd552a/Microsoft.RequirementCategory)
 # Week 1 Tasks
 
 Week 1 task is to demonstrate the understanding of the DevOps concepts, users, groups and permissions in Linux


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#679](https://dev.azure.com/devylawyer/3db72a94-2802-4ab6-80ee-da1adfdaf803/_workitems/edit/679). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.